### PR TITLE
Add user agent

### DIFF
--- a/src/__tests__/mailtrap_client.test.ts
+++ b/src/__tests__/mailtrap_client.test.ts
@@ -49,6 +49,8 @@ describe("MailtrapClient#send", () => {
         "Content-Type": "application/json",
         Authorization: "Bearer MY_API_TOKEN",
         Connection: "keep-alive",
+        "User-Agent":
+          "mailtrap-nodejs (https://github.com/railsware/mailtrap-nodejs)",
       });
       expect(mock.history.post[0].data).toEqual(
         "{" +
@@ -99,6 +101,8 @@ describe("MailtrapClient#send", () => {
         "Content-Type": "application/json",
         Authorization: "Bearer MY_API_TOKEN",
         Connection: "keep-alive",
+        "User-Agent":
+          "mailtrap-nodejs (https://github.com/railsware/mailtrap-nodejs)",
       });
       expect(mock.history.post[0].data).toEqual(
         "{" +

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export class MailtrapClient {
       headers: {
         Authorization: `Bearer ${token}`,
         Connection: "keep-alive",
+        "User-Agent":
+          "mailtrap-nodejs (https://github.com/railsware/mailtrap-nodejs)",
       },
       maxRedirects: 0,
       timeout: 10000,


### PR DESCRIPTION
## Motivation

Make the package clearly identifiable.

## Changes

- Add user agent header

## How to test

- [ ] No way to do it from the client side; you could change the `endpoint` and send the request to some web endpoint to inspect it - then it should show the User-Agent header
