### PR TITLE
Move nodemailer types to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "3.1.1",
   "author": "Railsware Products Studio LLC",
   "dependencies": {
-    "axios": ">=0.27"
+    "axios": ">=0.27",
+    "@types/nodemailer": "^6.4.9"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",
@@ -13,7 +14,6 @@
     "@jest/globals": "^29.3.1",
     "@types/jest": "^29.5.3",
     "@types/node": "^18.15.11",
-    "@types/nodemailer": "^6.4.9",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "axios-mock-adapter": "^1.21.2",


### PR DESCRIPTION
## Motivation

For resolving dependencies in package, npm requires to have them in `dependencies` instead of `devDependencies`. So we should move `@types/nodemailer` to dependencies.

## Changes

- Moved `@types/nodemailer` from `devDependencies` to `dependencies`.
