### PR TITLE
Bump version to v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.3.0] - 2024-01-31
+- Add support for Testing product API.
+  - All public routes from API V2 are now available in SDK.
+  - Refer to the [`examples`](examples) folder for the source code of this and other advanced examples.
+- Security updates.
+
 ## [3.2.0] - 2023-08-30
 - Add `mailtrap-nodemailer-transporter` for sending emails using HTTP API via `nodemailer`.
 - Security updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [3.3.0] - 2024-01-31
 - Add support for Testing product API.
   - All public routes from API V2 are now available in SDK.
-  - Refer to the [`examples`](examples) folder for the source code of this and other advanced examples.
+  - Refer to the [`examples`](examples) folder for code examples.
 - Security updates.
 
 ## [3.2.0] - 2023-08-30

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mailtrap",
   "description": "Official mailtrap.io API client",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Railsware Products Studio LLC",
   "dependencies": {
     "axios": ">=0.27"


### PR DESCRIPTION
## Motivation
- Release new version v3.3.0

## Changes

- Add support for Testing product API.
  - All public routes from API V2 are now available in SDK.
  - Refer to the [`examples`](examples) folder for code examples.
- Security updates.

## How to test
- n/a
