### PR TITLE
examples: fix Nodemailer transport example to render attachment inline

### DIFF
--- a/examples/sending/transport.ts
+++ b/examples/sending/transport.ts
@@ -54,6 +54,8 @@ transport.sendMail({
     {
       filename: "welcome.png",
       content: readFileSync("./welcome.png"),
+      cid: "welcome.png",
+      contentDisposition: "inline",
     },
   ],
 }).then(console.log)


### PR DESCRIPTION
## Motivation

Fixed the Nodemailer example to render the attachment image inline, like in other examples.

## Changes

Added the required options to the `attachments` config section of Nodemailer `send` call arguments

## How to test

Send an email using the `examples/sending/transport.ts` example and ensure that the attachment image is rendered inline in the email HTML body

## Images and GIFs

| Before | After  |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8b4ef8f8-f61f-47a2-8c87-1e1bb0380e88)| ![image](https://github.com/user-attachments/assets/dc05cd18-9d2d-474e-83b1-65f729dda0e0)  |
