### PR TITLE
Add badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-![TypeScript](https://badgen.net/badge/icon/TypeScript/?icon=typescript&label) [![test](https://github.com/railsware/mailtrap-nodejs/actions/workflows/test.yml/badge.svg)](https://github.com/railsware/mailtrap-nodejs/actions/workflows/test.yml)
+![TypeScript](https://img.shields.io/npm/types/mailtrap?logo=typescript&logoColor=white&label=%20)
+[![test](https://github.com/railsware/mailtrap-nodejs/actions/workflows/test.yml/badge.svg)](https://github.com/railsware/mailtrap-nodejs/actions/workflows/test.yml)
+[![NPM](https://shields.io/npm/v/mailtrap?logo=npm&logoColor=white)](https://www.npmjs.com/package/mailtrap)
+[![downloads](https://shields.io/npm/d18m/mailtrap)](https://www.npmjs.com/package/mailtrap)
 
 # Official Mailtrap Node.js client
 


### PR DESCRIPTION
## Motivation

Add link to NPM so it can be found without searching

## Changes

- Add the links
- Replace badgen.net with shields.io as the documentation is better

## How to test

- [ ] Badges should display and links should work

## Images and GIFs

![CleanShot 2024-08-06 at 16 48 06@2x](https://github.com/user-attachments/assets/4c4fbf56-e4e9-4a3c-8ad5-b86a0ab44001)
