### PR TITLE
Feature to add "reply_to" option when sending mails.

### DIFF
--- a/examples/sending/everything.ts
+++ b/examples/sending/everything.ts
@@ -12,6 +12,7 @@ import { MailtrapClient } from "mailtrap"
 const TOKEN = "<YOUR-TOKEN-HERE>";
 const SENDER_EMAIL = "<SENDER@YOURDOMAIN.COM>";
 const RECIPIENT_EMAIL = "<RECIPIENT@EMAIL.COM>";
+const REPLY_TO_EMAIL = "<REPLYTO@EMAIL.COM>";
 
 const client = new MailtrapClient({ token: TOKEN });
 
@@ -28,6 +29,7 @@ client
     from: { name: "Mailtrap Test", email: SENDER_EMAIL },
     to: [{ email: RECIPIENT_EMAIL }],
     subject: "Hello from Mailtrap!",
+    reply_to: { email: REPLY_TO_EMAIL },
     html: `
     <!doctype html>
     <html>

--- a/examples/sending/transport.ts
+++ b/examples/sending/transport.ts
@@ -11,6 +11,7 @@ import { MailtrapTransport } from "mailtrap"
 const TOKEN = "<YOUR-TOKEN-HERE>"
 const SENDER_EMAIL = "<SENDER@YOURDOMAIN.COM>";
 const RECIPIENT_EMAIL = "<RECIPIENT@EMAIL.COM>";
+const REPLY_TO_EMAIL = "<REPLYTO@EMAIL.COM>";
 
 const transport = Nodemailer.createTransport(MailtrapTransport({
   token: TOKEN,
@@ -26,6 +27,7 @@ transport.sendMail({
     address: SENDER_EMAIL,
     name: "Mailtrap Test"
   },
+  replyTo: REPLY_TO_EMAIL,
   subject: "Hello from Mailtrap!",
   html: `
   <!doctype html>

--- a/src/__tests__/adapters/mail.test.ts
+++ b/src/__tests__/adapters/mail.test.ts
@@ -1,7 +1,7 @@
 import adaptMail from "../../adapters/mail";
 
 import config from "../../config";
-import { adaptSingleRecipient } from "../../adapters/recipients";
+import { adaptSingleRecipient, adaptReplyToRecipient } from "../../adapters/recipients";
 
 const { ERRORS } = config;
 const { SUBJECT_REQUIRED, FROM_REQUIRED } = ERRORS;
@@ -24,6 +24,7 @@ describe("adapters/mail: ", () => {
           mockKey: "mock-value",
         },
         subject: "mock-subject",
+        replyTo: "mock-reply-to",
       };
 
       const expectedResult = {
@@ -33,6 +34,7 @@ describe("adapters/mail: ", () => {
         bcc: [],
         headers: data.headers,
         subject: data.subject,
+        reply_to: adaptReplyToRecipient(data.replyTo),
       };
       const result = adaptMail(data);
 
@@ -47,6 +49,7 @@ describe("adapters/mail: ", () => {
           mockKey: "mock-value",
         },
         attachments: [{ filename: "mock-filename", content: "mock-content" }],
+        replyTo: [],
       };
 
       const expectedResult = {
@@ -57,6 +60,7 @@ describe("adapters/mail: ", () => {
         bcc: [],
         headers: data.headers,
         attachments: data.attachments,
+        reply_to: adaptReplyToRecipient(data.replyTo),
       };
       const result = adaptMail(data);
 
@@ -74,6 +78,7 @@ describe("adapters/mail: ", () => {
         customVariables: {
           user_id: "mock-user_id",
         },
+        replyTo: ["mock-reply-to"],
       };
 
       const expectedResult = {
@@ -85,6 +90,7 @@ describe("adapters/mail: ", () => {
         headers: data.headers,
         attachments: data.attachments,
         custom_variables: data.customVariables,
+        reply_to: adaptReplyToRecipient(data.replyTo),
       };
       const result = adaptMail(data);
 

--- a/src/__tests__/adapters/mail.test.ts
+++ b/src/__tests__/adapters/mail.test.ts
@@ -1,7 +1,10 @@
 import adaptMail from "../../adapters/mail";
 
 import config from "../../config";
-import { adaptSingleRecipient, adaptReplyToRecipient } from "../../adapters/recipients";
+import {
+  adaptSingleRecipient,
+  adaptReplyToRecipient,
+} from "../../adapters/recipients";
 
 const { ERRORS } = config;
 const { SUBJECT_REQUIRED, FROM_REQUIRED } = ERRORS;

--- a/src/__tests__/adapters/recipients.test.ts
+++ b/src/__tests__/adapters/recipients.test.ts
@@ -1,5 +1,6 @@
 import adaptRecipients, {
   adaptSingleRecipient,
+  adaptReplyToRecipient,
 } from "../../adapters/recipients";
 
 describe("adapters/recipients: ", () => {
@@ -81,6 +82,62 @@ describe("adapters/recipients: ", () => {
         },
       ];
       const result = adaptRecipients(recipients);
+
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe("adaptReplyToRecipient(): ", () => {
+    it("returns undefined if recipients is invalid.", () => {
+      const recipients = undefined;
+
+      const expectedResult = undefined;
+      const result = adaptReplyToRecipient(recipients);
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("returns undefined if recipients is empty array.", () => {
+      const recipients: any = [];
+
+      const expectedResult = undefined;
+      const result = adaptReplyToRecipient(recipients);
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("returns adapted recipients if it's not an array.", () => {
+      const recipients = {
+        name: "mock-name",
+        address: "mock-email",
+      };
+
+      const expectedResult = {
+        name: recipients.name,
+        email: recipients.address,
+      };
+      const result = adaptReplyToRecipient(recipients);
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("returns first adapted recipient if it's an array.", () => {
+      const recipients = [
+        {
+          name: "mock-name-1",
+          address: "mock-email-1",
+        },
+        {
+          name: "mock-name-2",
+          address: "mock-email-2",
+        },
+      ];
+
+      const expectedResult = {
+        name: recipients[0].name,
+        email: recipients[0].address,
+      };
+      const result = adaptReplyToRecipient(recipients);
 
       expect(result).toEqual(expectedResult);
     });

--- a/src/adapters/mail.ts
+++ b/src/adapters/mail.ts
@@ -1,7 +1,10 @@
 import adaptAttachment from "./attachement";
 import adaptContent from "./content";
 import adaptHeaders from "./headers";
-import adaptRecipients, { adaptSingleRecipient, adaptReplyToRecipient } from "./recipients";
+import adaptRecipients, {
+  adaptSingleRecipient,
+  adaptReplyToRecipient,
+} from "./recipients";
 
 import CONFIG from "../config";
 

--- a/src/adapters/mail.ts
+++ b/src/adapters/mail.ts
@@ -1,7 +1,7 @@
 import adaptAttachment from "./attachement";
 import adaptContent from "./content";
 import adaptHeaders from "./headers";
-import adaptRecipients, { adaptSingleRecipient } from "./recipients";
+import adaptRecipients, { adaptSingleRecipient, adaptReplyToRecipient } from "./recipients";
 
 import CONFIG from "../config";
 
@@ -27,6 +27,7 @@ export default function adaptMail(data: MailtrapMailOptions): Mail | SendError {
     to: adaptRecipients(data.to),
     cc: adaptRecipients(data.cc),
     bcc: adaptRecipients(data.bcc),
+    reply_to: adaptReplyToRecipient(data.replyTo),
   };
 
   if (data.headers) {

--- a/src/adapters/recipients.ts
+++ b/src/adapters/recipients.ts
@@ -38,3 +38,27 @@ export default function adaptRecipients(
 
   return recipients.map(adaptSingleRecipient);
 }
+
+/**
+ * If there is no recipient or empty array is passed, then return undefined since it is an optional field.
+ * If it's not array, then adapt recipient and returns it.
+ * Otherwise, if type is array as nodemailer allows, we pick the first recipient 
+ * as Mailtrap doesn't support multiple reply-to recipients.
+ */
+export function adaptReplyToRecipient(
+  recipients:
+    | string
+    | NodemailerAddress
+    | Array<string | NodemailerAddress>
+    | undefined
+): Address | undefined {
+  if(!recipients || (Array.isArray(recipients) && recipients.length === 0)) {
+    return undefined;
+  }
+
+  if (!Array.isArray(recipients)) {
+    return adaptSingleRecipient(recipients);
+  }
+
+  return adaptSingleRecipient(recipients[0]);
+}

--- a/src/adapters/recipients.ts
+++ b/src/adapters/recipients.ts
@@ -42,7 +42,7 @@ export default function adaptRecipients(
 /**
  * If there is no recipient or empty array is passed, then return undefined since it is an optional field.
  * If it's not array, then adapt recipient and returns it.
- * Otherwise, if type is array as nodemailer allows, we pick the first recipient 
+ * Otherwise, if type is array as nodemailer allows, we pick the first recipient
  * as Mailtrap doesn't support multiple reply-to recipients.
  */
 export function adaptReplyToRecipient(
@@ -52,7 +52,7 @@ export function adaptReplyToRecipient(
     | Array<string | NodemailerAddress>
     | undefined
 ): Address | undefined {
-  if(!recipients || (Array.isArray(recipients) && recipients.length === 0)) {
+  if (!recipients || (Array.isArray(recipients) && recipients.length === 0)) {
     return undefined;
   }
 

--- a/src/types/mailtrap.ts
+++ b/src/types/mailtrap.ts
@@ -23,6 +23,7 @@ export type CommonMail = {
   attachments?: Attachment[];
   headers?: MailtrapHeaders;
   custom_variables?: CustomVariables;
+  reply_to?: Address;
 };
 
 export type TemplateVariables = Record<string, string | number | boolean>;


### PR DESCRIPTION
## Motivation
Mailtrap has the option of a ```reply_to``` field, but this currently does not exist in the SDK. This PR introduces the functionality to allow users to pass a ```reply_to``` email address, which will be used as the default reply email in email clients.

## Changes

- Added ```reply_to``` in the CommonMail type.
- Updated nodemailer adaptor to handle this change
- Updated the "everything" example to show how to use the ```reply_to``` feature.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced outgoing emails with a reply-to option, allowing responses to be directed to a designated address.
- **Tests**
	- Updated test scenarios to verify proper handling of the reply-to functionality across various recipient inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->