### PR TITLE
Version 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [4.1.0] - 2025-04-18
+- Add support for `reply_to` in Sending API (in https://github.com/railsware/mailtrap-nodejs/pull/58, thanks to @aolamide).
+
 ## [4.0.0] - 2025-02-28
 - BREAKING CHANGE: Missing params for the Testing API (here) are treated as errors (throw new Error(...)), not warnings.
 - BREAKING CHANGE: Removes send methods from the `BulkSendingAPI` and `TestingAPI` classes. There should be only one send method on the `MailtrapClient`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mailtrap",
   "description": "Official mailtrap.io API client",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Railsware Products Studio LLC",
   "dependencies": {
     "axios": ">=0.27"


### PR DESCRIPTION
## Motivation


## Changes

- Add support for `reply_to` in Sending API (in https://github.com/railsware/mailtrap-nodejs/pull/58, thanks to @aolamide).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to include details for version 4.1.0, highlighting support for the `reply_to` field in the Sending API.

- **Chores**
  - Bumped the version number to 4.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->