### PR TITLE
Standardize list types

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,4 @@ Everyone interacting in the Mailtrap project's codebases, issue trackers, chat r
 ## Compatibility with previous releases
 
 Versions of this package up to 2.0.2 were an [unofficial client](https://github.com/vchin/mailtrap-client) developed by [@vchin](https://github.com/vchin). Package version 3 is a completely new package. 
+

--- a/src/__tests__/lib/api/resources/ContactLists.test.ts
+++ b/src/__tests__/lib/api/resources/ContactLists.test.ts
@@ -4,7 +4,7 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import ContactListsApi from "../../../../lib/api/resources/ContactLists";
 import handleSendingError from "../../../../lib/axios-logger";
 import MailtrapError from "../../../../lib/MailtrapError";
-import { ContactList, ContactLists } from "../../../../types/api/contactlist";
+import { ContactList } from "../../../../types/api/contactlist";
 
 import CONFIG from "../../../../config";
 
@@ -61,7 +61,7 @@ describe("lib/api/resources/ContactLists: ", () => {
   describe("getAll(): ", () => {
     it("successfully gets all contact lists.", async () => {
       const endpoint = `${GENERAL_ENDPOINT}/api/accounts/${accountId}/contacts/lists`;
-      const expectedResponseData: ContactLists = [
+      const expectedResponseData: ContactList[] = [
         { id: 1, name: "Test List 1" },
         { id: 2, name: "Test List 2" },
       ];

--- a/src/lib/api/resources/ContactLists.ts
+++ b/src/lib/api/resources/ContactLists.ts
@@ -4,7 +4,6 @@ import CONFIG from "../../../config";
 import {
   ContactList,
   ContactListOptions,
-  ContactLists,
 } from "../../../types/api/contactlist";
 
 const { CLIENT_SETTINGS } = CONFIG;
@@ -26,7 +25,7 @@ export default class ContactListsApi {
   public async getList() {
     const url = `${this.contactListsURL}`;
 
-    return this.client.get<ContactLists, ContactLists>(url);
+    return this.client.get<ContactList[], ContactList[]>(url);
   }
 
   /**

--- a/src/types/api/contactlist.ts
+++ b/src/types/api/contactlist.ts
@@ -3,8 +3,6 @@ export interface ContactList {
   name: string;
 }
 
-export type ContactLists = ContactList[];
-
 export interface ContactListOptions {
   name: string;
 }

--- a/src/types/api/templates.ts
+++ b/src/types/api/templates.ts
@@ -25,5 +25,3 @@ export interface TemplateUpdateParams {
   body_html?: string;
   body_text?: string;
 }
-
-export type TemplateList = Template[];


### PR DESCRIPTION
## Motivation

use the same standard for the list types across APIs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused type aliases related to contact lists and templates.
  * Updated internal type annotations for improved consistency.
  * Added a trailing newline to the end of the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->