### PR TITLE
docs: clarify API key generation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The quickest way to send a single transactional email with only the required par
 import { MailtrapClient } from "mailtrap";
 
 const mailtrap = new MailtrapClient({
-  token: process.env.MAILTRAP_API_KEY, // your API key here https://mailtrap.io/api-tokens
+  token: process.env.MAILTRAP_API_KEY, // You can create your API key here https://mailtrap.io/api-tokens
 });
 
 mailtrap


### PR DESCRIPTION
This PR updates the README to improve clarity around API key generation.

What changed

Replaced the text
"your API key here https://mailtrap.io/api-tokens
"
with
"You can create your API key here https://mailtrap.io/api-tokens
".

Why

The previous phrasing could be misunderstood as suggesting that the key itself should be inserted into code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline code comment in the usage example for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->