### PR TITLE
Add draft-release.yml workflow placeholder

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,28 @@
+# Placeholder draft-release workflow
+#
+name: Draft Node.js Release
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Semver bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+jobs:
+  draft-release:
+    name: Draft Node.js Release (placeholder)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo inputs
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          echo "Placeholder draft-release workflow"
+          echo "bump_type=$BUMP_TYPE"
+          echo "No-op: implementation to follow."


### PR DESCRIPTION
## Motivation

Add workflow placeholder, so it will be possible to run the workflow when implementing it

## Changes

- Add workflow placeholder

## How to test

- [ ] Assert Draft Node.js workflow appears in Github Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manual draft release workflow with selectable patch, minor, or major version options.
  * The workflow currently serves as a placeholder and does not perform any release actions yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->