### PR TITLE
Implement draft-release.yml workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -74,10 +74,7 @@ jobs:
               if (error.status !== 404) throw error;
             }
 
-      - name: Update version in package.json
-        run: yarn version --new-version "${{ steps.bump.outputs.next }}" --no-git-tag-version
-
-      - name: Generate release notes from PRs since last tag
+      - name: Generate release notes, abort if nothing to release
         id: notes
         uses: actions/github-script@v7
         with:
@@ -85,15 +82,26 @@ jobs:
             const tag = '${{ steps.bump.outputs.tag }}';
 
             // Detect the previous release tag so notes only cover PRs since then.
-            let previousTag;
-            try {
-              const latest = await github.rest.repos.getLatestRelease({
+            const latest = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }).catch((error) => {
+              if (error.status === 404) return null;
+              throw error;
+            });
+            const previousTag = latest?.data.tag_name;
+
+            // Skip the rest of the release if nothing changed since the previous release.
+            if (previousTag) {
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                basehead: `${previousTag}...main`,
               });
-              previousTag = latest.data.tag_name;
-            } catch (error) {
-              if (error.status !== 404) throw error;
+              if (comparison.total_commits === 0) {
+                core.info(`No commits since ${previousTag}; nothing to release. Skipping.`);
+                return;
+              }
             }
 
             const { data } = await github.rest.repos.generateReleaseNotes({
@@ -103,9 +111,14 @@ jobs:
               ...(previousTag ? { previous_tag_name: previousTag } : {}),
             });
 
-            core.setOutput('release_notes', data.body || '* No changes since previous release');
+            core.setOutput('release_notes', data.body);
+
+      - name: Update version in package.json
+        if: steps.notes.outputs.release_notes != ''
+        run: yarn version --new-version "${{ steps.bump.outputs.next }}" --no-git-tag-version
 
       - name: Prepend new section to CHANGELOG.md
+        if: steps.notes.outputs.release_notes != ''
         uses: actions/github-script@v7
         env:
           NEXT: ${{ steps.bump.outputs.next }}
@@ -121,6 +134,7 @@ jobs:
             fs.writeFileSync('CHANGELOG.md', entry + original);
 
       - name: Commit, push, open PR
+        if: steps.notes.outputs.release_notes != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -139,6 +153,7 @@ jobs:
           ${{ steps.notes.outputs.release_notes }}"
 
       - name: Create draft GitHub release
+        if: steps.notes.outputs.release_notes != ''
         uses: actions/github-script@v7
         env:
           RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,4 +1,5 @@
-# Placeholder draft-release workflow
+# Drafts new mailtrap-nodejs release: bumps the version, regenerates the changelog from
+# merged PRs, and opens a release PR against main.
 #
 name: Draft Node.js Release
 on:
@@ -14,15 +15,144 @@ on:
           - major
         default: patch
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   draft-release:
-    name: Draft Node.js Release (placeholder)
+    name: Draft mailtrap-nodejs Release
     runs-on: ubuntu-latest
     steps:
-      - name: Echo inputs
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+
+      - name: Compute next version
+        id: bump
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const current = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+            const [major, minor, patch] = current.split('.').map(Number);
+            const next = {
+              major: `${major + 1}.0.0`,
+              minor: `${major}.${minor + 1}.0`,
+              patch: `${major}.${minor}.${patch + 1}`,
+            }[context.payload.inputs.bump_type];
+            const tag = `v${next}`;
+
+            core.info(`Bumping ${current} -> ${next}`);
+            core.setOutput('current', current);
+            core.setOutput('next', next);
+            core.setOutput('tag', tag);
+            core.setOutput('branch', `release-${tag}`);
+
+      - name: Abort if tag already exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag}`,
+              });
+              core.setFailed(`Tag ${tag} already exists`);
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+      - name: Update version in package.json
+        run: yarn version --new-version "${{ steps.bump.outputs.next }}" --no-git-tag-version
+
+      - name: Generate release notes from PRs since last tag
+        id: notes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+
+            // Detect the previous release tag so notes only cover PRs since then.
+            let previousTag;
+            try {
+              const latest = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              previousTag = latest.data.tag_name;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            const { data } = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              ...(previousTag ? { previous_tag_name: previousTag } : {}),
+            });
+
+            core.setOutput('release_notes', data.body || '* No changes since previous release');
+
+      - name: Prepend new section to CHANGELOG.md
+        uses: actions/github-script@v7
         env:
-          BUMP_TYPE: ${{ inputs.bump_type }}
+          NEXT: ${{ steps.bump.outputs.next }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}
+        with:
+          script: |
+            const fs = require('fs');
+            const version = process.env.NEXT;
+            const date = new Date().toISOString().slice(0, 10);
+            const releaseNotes = process.env.RELEASE_NOTES.trim();
+            const entry = `## [${version}] - ${date}\n\n${releaseNotes}\n\n`;
+            const original = fs.readFileSync('CHANGELOG.md', 'utf8');
+            fs.writeFileSync('CHANGELOG.md', entry + original);
+
+      - name: Commit, push, open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Placeholder draft-release workflow"
-          echo "bump_type=$BUMP_TYPE"
-          echo "No-op: implementation to follow."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.bump.outputs.branch }}"
+          git add package.json CHANGELOG.md
+          git commit -m "Release ${{ steps.bump.outputs.tag }}"
+          git push -u origin "${{ steps.bump.outputs.branch }}"
+          gh pr create \
+            --base main \
+            --head "${{ steps.bump.outputs.branch }}" \
+            --title "Release ${{ steps.bump.outputs.tag }}" \
+            --body "## Automated \`${{ inputs.bump_type }}\` bump from v${{ steps.bump.outputs.current }} to v${{ steps.bump.outputs.next }}
+
+          ${{ steps.notes.outputs.release_notes }}"
+
+      - name: Create draft GitHub release
+        uses: actions/github-script@v7
+        env:
+          RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              target_commitish: 'main',
+              name: tag,
+              body: process.env.RELEASE_NOTES,
+              draft: true,
+              prerelease: false,
+            });
+            core.info(`Draft release created: ${data.html_url}`);

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -137,20 +137,29 @@ jobs:
         if: steps.notes.outputs.release_notes != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          CURRENT: ${{ steps.bump.outputs.current }}
+          NEXT: ${{ steps.bump.outputs.next }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.release_notes }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${{ steps.bump.outputs.branch }}"
+          git checkout -b "$BRANCH"
           git add package.json CHANGELOG.md
-          git commit -m "Release ${{ steps.bump.outputs.tag }}"
-          git push -u origin "${{ steps.bump.outputs.branch }}"
+          git commit -m "Release $TAG"
+          git push -u origin "$BRANCH"
+          body_file="$(mktemp)"
+          {
+            printf '## Automated `%s` bump from v%s to v%s\n\n' "$BUMP_TYPE" "$CURRENT" "$NEXT"
+            printf '%s\n' "$RELEASE_NOTES"
+          } > "$body_file"
           gh pr create \
             --base main \
-            --head "${{ steps.bump.outputs.branch }}" \
-            --title "Release ${{ steps.bump.outputs.tag }}" \
-            --body "## Automated \`${{ inputs.bump_type }}\` bump from v${{ steps.bump.outputs.current }} to v${{ steps.bump.outputs.next }}
-
-          ${{ steps.notes.outputs.release_notes }}"
+            --head "$BRANCH" \
+            --title "Release $TAG" \
+            --body-file "$body_file"
 
       - name: Create draft GitHub release
         if: steps.notes.outputs.release_notes != ''


### PR DESCRIPTION
## Motivation

Automate mailtrap-nodejs releases

## Changes

- Implement draft-release.yml workflow

## How to test

- [ ] Trigger the workflow
- [ ] Assert workflow creates release PR and draft release

## Images and GIFs

<img width="1860" height="1568" alt="image" src="https://github.com/user-attachments/assets/df7ee6d2-16a3-4f55-9575-7cb90279bd2d" />
<img width="2584" height="1468" alt="image" src="https://github.com/user-attachments/assets/eee2b7e1-337c-4de4-ac86-d6dbf2e9a40e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated “Draft Node.js Release” workflow that computes the next semver version and release tag.
  * Automatically generates release notes and creates draft GitHub releases.
  * Updates versioning and the changelog, commits changes to a release branch, and opens a PR to merge into the main branch.
* **Bug Fixes**
  * Prevents duplicate releases by stopping when the computed release tag already exists.
  * Skips creating a release when there are no changes since the previous release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->