### PR TITLE
MT-22678: Add search param to contact lists getList

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Email Sandbox (Testing):
 Contact management:
 
 - Contacts CRUD & listing – [`contacts/everything.ts`](examples/contacts/everything.ts)
-- Contact lists CRUD & search by name – [`contact-lists/everything.ts`](examples/contact-lists/everything.ts)
+- Contact lists CRUD – [`contact-lists/everything.ts`](examples/contact-lists/everything.ts)
 - Custom fields CRUD – [`contact-fields/everything.ts`](examples/contact-fields/everything.ts)
 - Import/Export – [`contact-imports/everything.ts`](examples/contact-imports/everything.ts), [`contact-exports/everything.ts`](examples/contact-exports/everything.ts)
 - Events – [`contact-events/everything.ts`](examples/contact-events/everything.ts)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Email Sandbox (Testing):
 Contact management:
 
 - Contacts CRUD & listing – [`contacts/everything.ts`](examples/contacts/everything.ts)
-- Contact lists CRUD – [`contact-lists/everything.ts`](examples/contact-lists/everything.ts)
+- Contact lists CRUD & search by name – [`contact-lists/everything.ts`](examples/contact-lists/everything.ts)
 - Custom fields CRUD – [`contact-fields/everything.ts`](examples/contact-fields/everything.ts)
 - Import/Export – [`contact-imports/everything.ts`](examples/contact-imports/everything.ts), [`contact-exports/everything.ts`](examples/contact-exports/everything.ts)
 - Events – [`contact-events/everything.ts`](examples/contact-events/everything.ts)

--- a/examples/contact-lists/everything.ts
+++ b/examples/contact-lists/everything.ts
@@ -18,6 +18,10 @@ async function contactListsFlow() {
   const all = await client.contactLists.getList();
   console.log("All contact lists:", all);
 
+  // Filter contact lists by name (case-insensitive prefix match)
+  const filtered = await client.contactLists.getList({ search: "news" });
+  console.log("Filtered contact lists:", filtered);
+
   // Get a specific contact list
   const one = await client.contactLists.get(all[0].id);
   console.log("One contact list:", one);

--- a/src/__tests__/lib/api/ContactLists.test.ts
+++ b/src/__tests__/lib/api/ContactLists.test.ts
@@ -1,8 +1,17 @@
 import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 import ContactLists from "../../../lib/api/ContactLists";
+import handleSendingError from "../../../lib/axios-logger";
+import { ContactList } from "../../../types/api/contactlist";
+
+import CONFIG from "../../../config";
+
+const { CLIENT_SETTINGS } = CONFIG;
+const { GENERAL_ENDPOINT } = CLIENT_SETTINGS;
 
 describe("lib/api/ContactLists: ", () => {
+  let mock: AxiosMockAdapter;
   const accountId = 100;
   const contactListsAPI = new ContactLists(axios, accountId);
 
@@ -15,6 +24,55 @@ describe("lib/api/ContactLists: ", () => {
         expect(contactListsAPI).toHaveProperty("update");
         expect(contactListsAPI).toHaveProperty("delete");
       });
+    });
+  });
+
+  beforeAll(() => {
+    axios.interceptors.response.use(
+      (response) => response.data,
+      handleSendingError
+    );
+    mock = new AxiosMockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.reset();
+  });
+
+  describe("getList(): ", () => {
+    it("successfully gets all contact lists.", async () => {
+      const endpoint = `${GENERAL_ENDPOINT}/api/accounts/${accountId}/contacts/lists`;
+      const expectedResponseData: ContactList[] = [
+        { id: 1, name: "Test List 1" },
+        { id: 2, name: "Test List 2" },
+      ];
+
+      expect.assertions(2);
+
+      mock.onGet(endpoint).reply(200, expectedResponseData);
+      const result = await contactListsAPI.getList();
+
+      expect(mock.history.get[0].url).toEqual(endpoint);
+      expect(result).toEqual(expectedResponseData);
+    });
+
+    it("passes the search param to the request.", async () => {
+      const search = "news";
+      const endpoint = `${GENERAL_ENDPOINT}/api/accounts/${accountId}/contacts/lists`;
+      const expectedResponseData: ContactList[] = [
+        { id: 1, name: "Newsletter" },
+      ];
+
+      expect.assertions(3);
+
+      mock
+        .onGet(endpoint, { params: { search } })
+        .reply(200, expectedResponseData);
+      const result = await contactListsAPI.getList({ search });
+
+      expect(mock.history.get[0].url).toEqual(endpoint);
+      expect(mock.history.get[0].params).toEqual({ search });
+      expect(result).toEqual(expectedResponseData);
     });
   });
 });

--- a/src/__tests__/lib/api/resources/ContactLists.test.ts
+++ b/src/__tests__/lib/api/resources/ContactLists.test.ts
@@ -75,6 +75,25 @@ describe("lib/api/resources/ContactLists: ", () => {
       expect(result).toEqual(expectedResponseData);
     });
 
+    it("successfully gets contact lists filtered by name.", async () => {
+      const search = "news";
+      const endpoint = `${GENERAL_ENDPOINT}/api/accounts/${accountId}/contacts/lists`;
+      const expectedResponseData: ContactList[] = [
+        { id: 1, name: "Newsletter" },
+      ];
+
+      expect.assertions(3);
+
+      mock
+        .onGet(endpoint, { params: { search } })
+        .reply(200, expectedResponseData);
+      const result = await contactListsAPI.getList({ search });
+
+      expect(mock.history.get[0].url).toEqual(endpoint);
+      expect(mock.history.get[0].params).toEqual({ search });
+      expect(result).toEqual(expectedResponseData);
+    });
+
     it("fails with error.", async () => {
       const endpoint = `${GENERAL_ENDPOINT}/api/accounts/${accountId}/contacts/lists`;
       const expectedErrorMessage = "Request failed with status code 400";

--- a/src/lib/api/resources/ContactLists.ts
+++ b/src/lib/api/resources/ContactLists.ts
@@ -4,6 +4,7 @@ import CONFIG from "../../../config";
 import {
   ContactList,
   ContactListOptions,
+  ContactListsListOptions,
 } from "../../../types/api/contactlist";
 
 const { CLIENT_SETTINGS } = CONFIG;
@@ -20,12 +21,17 @@ export default class ContactListsApi {
   }
 
   /**
-   * Get all contact lists.
+   * Get all contact lists. Optionally filter by name via a case-insensitive
+   * prefix match with `search`.
    */
-  public async getList() {
-    const url = `${this.contactListsURL}`;
+  public async getList(options?: ContactListsListOptions) {
+    const params = {
+      ...(options?.search && { search: options.search }),
+    };
 
-    return this.client.get<ContactList[], ContactList[]>(url);
+    return this.client.get<ContactList[], ContactList[]>(this.contactListsURL, {
+      params,
+    });
   }
 
   /**

--- a/src/types/api/contactlist.ts
+++ b/src/types/api/contactlist.ts
@@ -6,3 +6,7 @@ export interface ContactList {
 export interface ContactListOptions {
   name: string;
 }
+
+export interface ContactListsListOptions {
+  search?: string;
+}


### PR DESCRIPTION
## Motivation

https://railsware.atlassian.net/browse/MT-22678

## Changes

- Add an optional `{ search }` option to `contactLists.getList` — filters contact lists by name (case-insensitive prefix match), per the OpenAPI `GET /api/contacts/lists` param. Sent only when provided, so the no-arg call is unchanged.

## How to test

- [ ] `client.contactLists.getList()` — returns all contact lists (unchanged behaviour).
- [ ] `client.contactLists.getList({ search: "news" })` — returns only lists whose name starts with "news" (case-insensitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact list search by name using an optional search term.
  * Search supports case-insensitive prefix matching.
  * Updated the contact list example to demonstrate filtered results.
* **Documentation**
  * Updated supported functionality documentation to include contact list search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->