### PR TITLE
Sync webhook types with the current API

### DIFF
--- a/src/__tests__/lib/api/resources/Webhooks.test.ts
+++ b/src/__tests__/lib/api/resources/Webhooks.test.ts
@@ -147,6 +147,37 @@ describe("lib/api/resources/Webhooks: ", () => {
         }
       }
     });
+
+    it("creates an inbound_receiving webhook linked to an inbox.", async () => {
+      const inboundParams = {
+        url: "https://example.com/mailtrap/webhooks",
+        webhook_type: "inbound_receiving" as const,
+        payload_format: "json" as const,
+        inbound_inbox_id: 1,
+      };
+      const inboundResponseData = {
+        data: {
+          id: 3,
+          url: "https://example.com/mailtrap/webhooks",
+          active: true,
+          webhook_type: "inbound_receiving",
+          payload_format: "json",
+          inbound_inbox_id: 1,
+          signing_secret: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+        },
+      };
+      const endpoint = `${GENERAL_ENDPOINT}/api/accounts/${accountId}/webhooks`;
+      const expectedBody = { webhook: inboundParams };
+
+      expect.assertions(3);
+
+      mock.onPost(endpoint, expectedBody).reply(200, inboundResponseData);
+      const result = await webhooksAPI.create(inboundParams);
+
+      expect(mock.history.post[0].url).toEqual(endpoint);
+      expect(JSON.parse(mock.history.post[0].data)).toEqual(expectedBody);
+      expect(result).toEqual(inboundResponseData);
+    });
   });
 
   describe("get(): ", () => {

--- a/src/lib/api/resources/Webhooks.ts
+++ b/src/lib/api/resources/Webhooks.ts
@@ -59,9 +59,9 @@ export default class WebhooksApi {
   }
 
   /**
-   * Update an existing webhook. Only `url`, `active`, `payload_format`, and
-   * `event_types` can be changed; `webhook_type`, `sending_stream`, and
-   * `domain_id` are immutable after creation.
+   * Update an existing webhook. Only `url`, `active`, `payload_format`,
+   * `event_types`, and `inbound_inbox_id` can be changed; `webhook_type`,
+   * `sending_stream`, and `domain_id` are immutable after creation.
    */
   public async update(id: number, params: UpdateWebhookParams) {
     const url = `${this.webhooksURL}/${id}`;

--- a/src/types/api/webhooks.ts
+++ b/src/types/api/webhooks.ts
@@ -1,4 +1,8 @@
-export type WebhookType = "email_sending" | "audit_log";
+export type WebhookType =
+  | "email_sending"
+  | "campaigns"
+  | "audit_log"
+  | "inbound_receiving";
 
 export type PayloadFormat = "json" | "jsonlines";
 
@@ -23,6 +27,7 @@ export type Webhook = {
   payload_format: PayloadFormat;
   sending_stream?: SendingStream | null;
   domain_id?: number | null;
+  inbound_inbox_id?: number | null;
   event_types?: WebhookEventType[];
 };
 
@@ -42,6 +47,7 @@ export type CreateWebhookParams = {
   sending_stream?: SendingStream;
   event_types?: WebhookEventType[];
   domain_id?: number;
+  inbound_inbox_id?: number;
 };
 
 export type WebhookWithSigningSecret = Webhook & {
@@ -57,6 +63,7 @@ export type UpdateWebhookParams = {
   active?: boolean;
   payload_format?: PayloadFormat;
   event_types?: WebhookEventType[];
+  inbound_inbox_id?: number;
 };
 
 export type UpdateWebhookResponse = {


### PR DESCRIPTION
## Changes

Brings the SDK's webhook management types in line with the current Webhooks API (per the OpenAPI spec).

- `WebhookType` — add the two missing members: `campaigns` and `inbound_receiving` (previously only `email_sending` and `audit_log`).
- Add `inbound_inbox_id` to `Webhook` (`number | null`), `CreateWebhookParams`, and `UpdateWebhookParams` (`number`), used by `inbound_receiving` webhooks.
- Update the `update()` doc comment, which no longer omitted `inbound_inbox_id` from the mutable fields.
- Add a `create()` test covering an `inbound_receiving` webhook linked to an inbox.

`SendingStream` and `WebhookEventType` already matched the API and were left unchanged.